### PR TITLE
Fix File Server Proxy Issues

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiDotNetAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiDotNetAPI.kt
@@ -220,11 +220,11 @@ open class LokiDotNetAPI(private val userHexEncodedPublicKey: String, private va
         if (server == LokiFileServerAPI.shared.server) {
             request.addHeader("Authorization", "Bearer loki")
             // Uploads to the Loki File Server shouldn't include any personally identifiable information, so use a dummy auth token
-            promise = LokiFileServerProxy(server).execute(request.build())
+            promise = LokiFileServerProxy(server, true).execute(request.build())
         } else {
             promise = getAuthToken(server).bind { token ->
                 request.addHeader("Authorization", "Bearer $token")
-                LokiFileServerProxy(server).execute(request.build())
+                LokiFileServerProxy(server, true).execute(request.build())
             }
         }
         return promise.map { response ->


### PR DESCRIPTION
This has 2 fixes:

1. Only search for file server nodes >= 2.0.2 if we're uploading something. This is self explanatory as those specific node versions are needed to make a request above 1mb of data.
2. Remove promise recursion in `getFileServerProxy` which inevitably causes `LokiAPI.sharedContext` to be blocked.
    - This was done by splitting the recursive part out into another function and just passing down the deferred promise.
