### PR TITLE
Increase Message TTL

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceDataMessage.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceDataMessage.java
@@ -11,6 +11,7 @@ import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.messages.shared.SharedContact;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 import org.whispersystems.signalservice.loki.api.multidevice.DeviceLink;
+import org.whispersystems.signalservice.loki.messaging.TTLUtilities;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -289,11 +290,12 @@ public class SignalServiceDataMessage {
   }
 
   public int getTTL() {
-    int minute = 60 * 1000;
-    int day = 24 * 60 * minute;
-    if (deviceLink.isPresent()) { return 2 * minute; }
-    if (isFriendRequest || isUnlinkingRequest) { return 4 * day; }
-    return day;
+    TTLUtilities.MessageType messageType = TTLUtilities.MessageType.Regular;
+    if (deviceLink.isPresent()) { messageType = TTLUtilities.MessageType.LinkDevice; }
+    else if (isFriendRequest) { messageType = TTLUtilities.MessageType.FriendRequest; }
+    else if (isUnlinkingRequest) { messageType = TTLUtilities.MessageType.UnlinkDevice; }
+    else if (isSessionRequest) { messageType = TTLUtilities.MessageType.SessionRequest; }
+    return TTLUtilities.getTTL$signal_service_java(messageType);
   }
 
   public boolean hasData() {

--- a/java/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceTypingMessage.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceTypingMessage.java
@@ -1,6 +1,7 @@
 package org.whispersystems.signalservice.api.messages;
 
 import org.whispersystems.libsignal.util.guava.Optional;
+import org.whispersystems.signalservice.loki.messaging.TTLUtilities;
 
 public class SignalServiceTypingMessage {
 
@@ -38,6 +39,5 @@ public class SignalServiceTypingMessage {
     return action == Action.STOPPED;
   }
 
-  // 1 minute
-  public int getTTL() { return 2 * 60 * 1000; }
+  public int getTTL() { return TTLUtilities.getTTL$signal_service_java(TTLUtilities.MessageType.TypingIndicator); }
 }

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
@@ -45,7 +45,6 @@ class LokiAPI private constructor(private val userHexEncodedPublicKey: String, p
         private val useOnionRequests = true
 
         internal val defaultTimeout: Long = 20
-        internal val defaultMessageTTL = 24 * 60 * 60 * 1000
         internal var powDifficulty = 2
         // endregion
 

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiMessage.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiMessage.kt
@@ -7,6 +7,7 @@ import org.whispersystems.signalservice.internal.util.Base64
 import org.whispersystems.signalservice.loki.crypto.ProofOfWork
 import org.whispersystems.signalservice.loki.messaging.LokiMessageWrapper
 import org.whispersystems.signalservice.loki.messaging.SignalMessageInfo
+import org.whispersystems.signalservice.loki.messaging.TTLUtilities
 import org.whispersystems.signalservice.loki.utilities.prettifiedDescription
 
 internal data class LokiMessage(
@@ -45,7 +46,7 @@ internal data class LokiMessage(
                 val wrappedMessage = LokiMessageWrapper.wrap(message)
                 val data = Base64.encodeBytes(wrappedMessage)
                 val destination = message.recipientID
-                var ttl = LokiAPI.defaultMessageTTL
+                var ttl = TTLUtilities.fallbackMessageTTL
                 val messageTTL = message.ttl
                 if (messageTTL != null && messageTTL != 0) { ttl = messageTTL }
                 val isPing = message.isPing

--- a/java/src/main/java/org/whispersystems/signalservice/loki/messaging/TTLUtilities.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/messaging/TTLUtilities.kt
@@ -1,0 +1,37 @@
+package org.whispersystems.signalservice.loki.messaging
+
+internal object TTLUtilities {
+
+    /**
+     * If a message type specifies an invalid TTL, this will be used.
+     */
+    internal val fallbackMessageTTL = 4 * 24 * 60 * 60 * 1000
+
+    internal enum class MessageType {
+        Address, // TODO: Unused?
+        Ephemeral, // TODO: Unused?
+        FriendRequest,
+        LinkDevice,
+        Regular,
+        SessionRequest,
+        TypingIndicator,
+        UnlinkDevice
+    }
+
+    @JvmStatic
+    internal fun getTTL(messageType: MessageType): Int {
+        val minuteInMs = 60 * 1000
+        val hourInMs = 60 * minuteInMs
+        val dayInMs = 24 * hourInMs
+        return when (messageType) {
+            MessageType.Address -> 1 * minuteInMs
+            MessageType.Ephemeral -> 4 * dayInMs - 1 * hourInMs
+            MessageType.FriendRequest -> 4 * dayInMs
+            MessageType.LinkDevice -> 4 * minuteInMs
+            MessageType.Regular -> 2 * dayInMs
+            MessageType.SessionRequest -> 4 * dayInMs - 1 * hourInMs
+            MessageType.TypingIndicator -> 1 * minuteInMs
+            MessageType.UnlinkDevice -> 4 * dayInMs
+        }
+    }
+}


### PR DESCRIPTION
Service nodes currently only storage messages for a day, so if a user sends a message to a second user, and that second user waits for more than a day before opening the app, the message won't be retrieved. This PR mitigates that problem a bit by simply increasing the message TTL.