### PR TITLE
Update Seed Nodes

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiSwarmAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiSwarmAPI.kt
@@ -41,7 +41,7 @@ class LokiSwarmAPI private constructor(private val database: LokiAPIDatabaseProt
         // endregion
 
         // region Clearnet Setup
-        private val seedNodePool: Set<String> = setOf( "http://storage.seed1.loki.network:22023", "http://storage.seed2.loki.network:38157", "http://149.56.148.124:38157" )
+        private val seedNodePool: Set<String> = setOf( "http://storage.seed1.loki.network:22023", "http://storage.seed2.loki.network:22023", "http://144.76.164.202:22023" )
 
         internal var randomSnodePool: MutableSet<LokiAPITarget> = mutableSetOf()
         // endregion


### PR DESCRIPTION
Replacing mainnet seed nodes with testnet port with the correct (now-working) correct mainnet port.
Kee wants to replace imaginary.seed due to SSL issues, it was using the IP, I've replaced it with the IP for public.loki.foundation for now. 

Not sure where you configure the android testnet config, so I'm not sure I did this right...

But when we enable SSL, we'll need hosts. And for the dude having DNS issues with our seeds, we will either need to disable SSL verification or keep an http port open for him