### PR TITLE
Onion Requests 2.0

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
@@ -20,7 +20,7 @@ import org.whispersystems.signalservice.loki.utilities.retryIfNeeded
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 
-class LokiAPI private constructor(private val userHexEncodedPublicKey: String, private val database: LokiAPIDatabaseProtocol, private val broadcaster: Broadcaster) {
+class LokiAPI private constructor(private val userHexEncodedPublicKey: String, private val database: LokiAPIDatabaseProtocol, public val broadcaster: Broadcaster) {
 
     companion object {
         val messageSendingContext = Kovenant.createContext("LokiAPIMessageSendingContext")

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
@@ -256,15 +256,15 @@ class LokiAPI private constructor(private val userHexEncodedPublicKey: String, p
 
     // region Error Handling
     private fun dropSnodeIfNeeded(snode: LokiAPITarget, hexEncodedPublicKey: String) {
-        val oldFailureCount = LokiSwarmAPI.failureCount[snode] ?: 0
+        val oldFailureCount = LokiSwarmAPI.shared.failureCount[snode] ?: 0
         val newFailureCount = oldFailureCount + 1
-        LokiSwarmAPI.failureCount[snode] = newFailureCount
+        LokiSwarmAPI.shared.failureCount[snode] = newFailureCount
         Log.d("Loki", "Couldn't reach snode at $snode; setting failure count to $newFailureCount.")
         if (newFailureCount >= LokiSwarmAPI.failureThreshold) {
             Log.d("Loki", "Failure threshold reached for: $snode; dropping it.")
             LokiSwarmAPI.shared.dropSnodeIfNeeded(snode, hexEncodedPublicKey) // Remove it from the swarm cache associated with the given public key
-            LokiSwarmAPI.randomSnodePool.remove(snode) // Remove it from the random snode pool
-            LokiSwarmAPI.failureCount[snode] = 0
+            LokiSwarmAPI.shared.snodePool = LokiSwarmAPI.shared.snodePool.toMutableSet().minus(snode).toSet() // Remove it from the random snode pool
+            LokiSwarmAPI.shared.failureCount[snode] = 0
         }
     }
 

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPI.kt
@@ -20,7 +20,7 @@ import org.whispersystems.signalservice.loki.utilities.retryIfNeeded
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 
-class LokiAPI private constructor(private val userHexEncodedPublicKey: String, private val database: LokiAPIDatabaseProtocol, public val broadcaster: Broadcaster) {
+class LokiAPI private constructor(private val userHexEncodedPublicKey: String, public val database: LokiAPIDatabaseProtocol, public val broadcaster: Broadcaster) {
 
     companion object {
         val messageSendingContext = Kovenant.createContext("LokiAPIMessageSendingContext")

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPITarget.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiAPITarget.kt
@@ -1,6 +1,6 @@
 package org.whispersystems.signalservice.loki.api
 
-class LokiAPITarget(val address: String, val port: Int, val publicKeySet: KeySet?) {
+public class LokiAPITarget(val address: String, val port: Int, val publicKeySet: KeySet?) {
 
     internal enum class Method(val rawValue: String) {
         /**

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiSwarmAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiSwarmAPI.kt
@@ -20,10 +20,15 @@ import java.io.IOException
 import java.security.SecureRandom
 
 class LokiSwarmAPI private constructor(private val database: LokiAPIDatabaseProtocol) {
+    internal var failureCount: MutableMap<LokiAPITarget, Int> = mutableMapOf()
+    internal var snodeVersions: MutableMap<LokiAPITarget, String> = mutableMapOf()
+
+    internal var snodePool: Set<LokiAPITarget>
+        get() = database.getSnodePool()
+        set(newValue) { database.setSnodePool(newValue) }
 
     companion object {
-        internal var failureCount: MutableMap<LokiAPITarget, Int> = mutableMapOf()
-        internal var snodeVersions: MutableMap<LokiAPITarget, String> = mutableMapOf()
+        private val seedNodePool: Set<String> = setOf( "https://storage.seed1.loki.network", "https://storage.seed3.loki.network", "https://public.loki.foundation" )
 
         // region Settings
         private val minimumSnodeCount = 2
@@ -40,155 +45,139 @@ class LokiSwarmAPI private constructor(private val database: LokiAPIDatabaseProt
             shared = LokiSwarmAPI(database)
         }
         // endregion
-
-        // region Clearnet Setup
-        private val seedNodePool: Set<String> = setOf( "https://storage.seed1.loki.network", "https://storage.seed3.loki.network", "https://public.loki.foundation" )
-
-        internal var randomSnodePool: MutableSet<LokiAPITarget> = mutableSetOf()
-        // endregion
-
-        // region Swarm API
-        internal fun getRandomSnode(): Promise<LokiAPITarget, Exception> {
-            if (randomSnodePool.isEmpty()) {
-                val target = seedNodePool.random()
-                val url = "$target/json_rpc"
-                Log.d("Loki", "Populating snode pool using: $target.")
-                val parameters = mapOf(
-                    "method" to "get_n_service_nodes",
-                    "params" to mapOf(
-                        "active_only" to true,
-                        "fields" to mapOf( "public_ip" to true, "storage_port" to true, "pubkey_x25519" to true, "pubkey_ed25519" to true )
-                    )
-                )
-                val deferred = deferred<LokiAPITarget, Exception>()
-                deferred<LokiAPITarget, Exception>(LokiAPI.sharedContext)
-                Thread {
-                    try {
-                        val json = HTTP.execute(HTTP.Verb.POST, url, parameters)
-                        val intermediate = json["result"] as? Map<*, *>
-                        val rawTargets = intermediate?.get("service_node_states") as? List<*>
-                        if (rawTargets != null) {
-                            randomSnodePool = rawTargets.mapNotNull { rawTarget ->
-                                val rawTargetAsJSON = rawTarget as? Map<*, *>
-                                val address = rawTargetAsJSON?.get("public_ip") as? String
-                                val port = rawTargetAsJSON?.get("storage_port") as? Int
-                                val ed25519Key = rawTargetAsJSON?.get("pubkey_ed25519") as? String
-                                val x25519Key = rawTargetAsJSON?.get("pubkey_x25519") as? String
-                                if (address != null && port != null && ed25519Key != null && x25519Key != null && address != "0.0.0.0") {
-                                    LokiAPITarget("https://$address", port, LokiAPITarget.KeySet(ed25519Key, x25519Key))
-                                } else {
-                                    Log.d("Loki", "Failed to parse: ${rawTarget?.prettifiedDescription()}.")
-                                    null
-                                }
-                            }.toMutableSet()
-                            try {
-                                deferred.resolve(randomSnodePool.getRandomElement())
-                            } catch (exception: Exception) {
-                                Log.d("Loki", "Got an empty snode pool from: $target.")
-                                deferred.reject(LokiAPI.Error.Generic)
-                            }
-                        } else {
-                            Log.d("Loki", "Failed to update snode pool from: ${(rawTargets as List<*>?)?.prettifiedDescription()}.")
-                            deferred.reject(LokiAPI.Error.Generic)
-                        }
-                    } catch (exception: Exception) {
-                        deferred.reject(exception)
-                    }
-                }.start()
-                return deferred.promise
-            } else {
-                return Promise.of(randomSnodePool.getRandomElement())
-            }
-        }
-
-        internal fun getFileServerProxy(): Promise<LokiAPITarget, Exception> {
-            val deferred = deferred<LokiAPITarget, Exception>(LokiAPI.sharedContext)
-            Thread {
-                getFileServerProxyInternal(deferred)
-            }.start()
-            return deferred.promise
-        }
-
-        /**
-         * Blocks the calling thread.
-         */
-        private fun getFileServerProxyInternal(deferred: Deferred<LokiAPITarget, Exception>, failureCount: Int = 0) {
-            if (deferred.promise.isDone()) { return }
-            val candidate: LokiAPITarget
-            try {
-                candidate = getRandomSnode().get()
-            } catch (e: Exception) {
-                deferred.reject(e)
-                return
-            }
-            val maxFailureCount = 3
-            try {
-                val version = getVersion(candidate).get()
-                if (version >= "2.0.2") {
-                    Log.d("Loki", "Using file server proxy with version number $version.")
-                    deferred.resolve(candidate)
-                } else {
-                    Log.d("Loki", "Rejecting file server proxy with version number $version.")
-                    getFileServerProxyInternal(deferred, failureCount)
-                }
-            } catch (e: Exception) {
-                if (failureCount < maxFailureCount) {
-                    getFileServerProxyInternal(deferred, failureCount + 1)
-                } else {
-                    deferred.reject(e)
-                }
-            }
-        }
-
-        private fun getVersion(snode: LokiAPITarget): Promise<String, Exception> {
-            val version = snodeVersions[snode]
-            if (version != null) { return Promise.of(version) }
-            val deferred = deferred<String, Exception>()
-            val url = "${snode.address}:${snode.port}/get_stats/v1"
-            val request = Request.Builder().url(url).get()
-            val connection = LokiHTTPClient(LokiAPI.defaultTimeout).getClearnetConnection()
-            connection.newCall(request.build()).enqueue(object : Callback {
-
-                override fun onResponse(call: Call, response: Response) {
-                    when (response.code()) {
-                        200 -> {
-                            val bodyAsString = response.body()!!.string()
-                            val body = JsonUtil.fromJson(bodyAsString, Map::class.java)
-                            @Suppress("NAME_SHADOWING") val version = body?.get("version") as? String
-                            if (version != null) {
-                                snodeVersions[snode] = version
-                                deferred.resolve(version)
-                            } else {
-                                deferred.reject(LokiAPI.Error.MissingSnodeVersion)
-                            }
-                        } else -> {
-                            Log.d("Loki", "Couldn't reach $snode.")
-                            deferred.reject(LokiAPI.Error.Generic)
-                        }
-                    }
-                }
-
-                override fun onFailure(call: Call, exception: IOException) {
-                    Log.d("Loki", "Couldn't reach $snode.")
-                    deferred.reject(exception)
-                }
-            })
-            return deferred.promise
-        }
-        // endregion
     }
-
-    // region Caching
-    internal fun dropSnodeIfNeeded(target: LokiAPITarget, hexEncodedPublicKey: String) {
-        val swarm = database.getSwarmCache(hexEncodedPublicKey)?.toMutableSet()
-        if (swarm != null && swarm.contains(target)) {
-            swarm.remove(target)
-            database.setSwarmCache(hexEncodedPublicKey, swarm)
-        }
-    }
-    // endregion
 
     // region Swarm API
+    internal fun getRandomSnode(): Promise<LokiAPITarget, Exception> {
+        if (snodePool.isEmpty()) {
+            val target = seedNodePool.random()
+            val url = "$target/json_rpc"
+            Log.d("Loki", "Populating snode pool using: $target.")
+            val parameters = mapOf(
+                "method" to "get_n_service_nodes",
+                "params" to mapOf(
+                    "active_only" to true,
+                    "fields" to mapOf( "public_ip" to true, "storage_port" to true, "pubkey_x25519" to true, "pubkey_ed25519" to true )
+                )
+            )
+            val deferred = deferred<LokiAPITarget, Exception>()
+            deferred<LokiAPITarget, Exception>(LokiAPI.sharedContext)
+            Thread {
+                try {
+                    val json = HTTP.execute(HTTP.Verb.POST, url, parameters)
+                    val intermediate = json["result"] as? Map<*, *>
+                    val rawTargets = intermediate?.get("service_node_states") as? List<*>
+                    if (rawTargets != null) {
+                        val snodePool = rawTargets.mapNotNull { rawTarget ->
+                            val rawTargetAsJSON = rawTarget as? Map<*, *>
+                            val address = rawTargetAsJSON?.get("public_ip") as? String
+                            val port = rawTargetAsJSON?.get("storage_port") as? Int
+                            val ed25519Key = rawTargetAsJSON?.get("pubkey_ed25519") as? String
+                            val x25519Key = rawTargetAsJSON?.get("pubkey_x25519") as? String
+                            if (address != null && port != null && ed25519Key != null && x25519Key != null && address != "0.0.0.0") {
+                                LokiAPITarget("https://$address", port, LokiAPITarget.KeySet(ed25519Key, x25519Key))
+                            } else {
+                                Log.d("Loki", "Failed to parse: ${rawTarget?.prettifiedDescription()}.")
+                                null
+                            }
+                        }.toMutableSet()
+                        Log.d("Loki", "Persisting snode pool to database.")
+                        this.snodePool = snodePool
+                        try {
+                            deferred.resolve(snodePool.getRandomElement())
+                        } catch (exception: Exception) {
+                            Log.d("Loki", "Got an empty snode pool from: $target.")
+                            deferred.reject(LokiAPI.Error.Generic)
+                        }
+                    } else {
+                        Log.d("Loki", "Failed to update snode pool from: ${(rawTargets as List<*>?)?.prettifiedDescription()}.")
+                        deferred.reject(LokiAPI.Error.Generic)
+                    }
+                } catch (exception: Exception) {
+                    deferred.reject(exception)
+                }
+            }.start()
+            return deferred.promise
+        } else {
+            return Promise.of(snodePool.getRandomElement())
+        }
+    }
+
+    internal fun getFileServerProxy(): Promise<LokiAPITarget, Exception> {
+        val deferred = deferred<LokiAPITarget, Exception>(LokiAPI.sharedContext)
+        Thread {
+            getFileServerProxyInternal(deferred)
+        }.start()
+        return deferred.promise
+    }
+
+    /**
+     * Blocks the calling thread.
+     */
+    private fun getFileServerProxyInternal(deferred: Deferred<LokiAPITarget, Exception>, failureCount: Int = 0) {
+        if (deferred.promise.isDone()) { return }
+        val candidate: LokiAPITarget
+        try {
+            candidate = getRandomSnode().get()
+        } catch (e: Exception) {
+            deferred.reject(e)
+            return
+        }
+        val maxFailureCount = 3
+        try {
+            val version = getVersion(candidate).get()
+            if (version >= "2.0.2") {
+                Log.d("Loki", "Using file server proxy with version number $version.")
+                deferred.resolve(candidate)
+            } else {
+                Log.d("Loki", "Rejecting file server proxy with version number $version.")
+                getFileServerProxyInternal(deferred, failureCount)
+            }
+        } catch (e: Exception) {
+            if (failureCount < maxFailureCount) {
+                getFileServerProxyInternal(deferred, failureCount + 1)
+            } else {
+                deferred.reject(e)
+            }
+        }
+    }
+
+    private fun getVersion(snode: LokiAPITarget): Promise<String, Exception> {
+        val version = snodeVersions[snode]
+        if (version != null) { return Promise.of(version) }
+        val deferred = deferred<String, Exception>()
+        val url = "${snode.address}:${snode.port}/get_stats/v1"
+        val request = Request.Builder().url(url).get()
+        val connection = LokiHTTPClient(LokiAPI.defaultTimeout).getClearnetConnection()
+        connection.newCall(request.build()).enqueue(object : Callback {
+
+            override fun onResponse(call: Call, response: Response) {
+                when (response.code()) {
+                    200 -> {
+                        val bodyAsString = response.body()!!.string()
+                        val body = JsonUtil.fromJson(bodyAsString, Map::class.java)
+                        @Suppress("NAME_SHADOWING") val version = body?.get("version") as? String
+                        if (version != null) {
+                            snodeVersions[snode] = version
+                            deferred.resolve(version)
+                        } else {
+                            deferred.reject(LokiAPI.Error.MissingSnodeVersion)
+                        }
+                    } else -> {
+                    Log.d("Loki", "Couldn't reach $snode.")
+                    deferred.reject(LokiAPI.Error.Generic)
+                }
+                }
+            }
+
+            override fun onFailure(call: Call, exception: IOException) {
+                Log.d("Loki", "Couldn't reach $snode.")
+                deferred.reject(exception)
+            }
+        })
+        return deferred.promise
+    }
+
     internal fun getSwarm(hexEncodedPublicKey: String): Promise<Set<LokiAPITarget>, Exception> {
         val cachedSwarm = database.getSwarmCache(hexEncodedPublicKey)
         if (cachedSwarm != null && cachedSwarm.size >= minimumSnodeCount) {
@@ -215,6 +204,16 @@ class LokiSwarmAPI private constructor(private val database: LokiAPIDatabaseProt
     internal fun getTargetSnodes(hexEncodedPublicKey: String): Promise<List<LokiAPITarget>, Exception> {
         // SecureRandom() should be cryptographically secure
         return getSwarm(hexEncodedPublicKey).map { it.shuffled(SecureRandom()).take(targetSnodeCount) }
+    }
+    // endregion
+
+    // region Caching
+    internal fun dropSnodeIfNeeded(target: LokiAPITarget, hexEncodedPublicKey: String) {
+        val swarm = database.getSwarmCache(hexEncodedPublicKey)?.toMutableSet()
+        if (swarm != null && swarm.contains(target)) {
+            swarm.remove(target)
+            database.setSwarmCache(hexEncodedPublicKey, swarm)
+        }
     }
     // endregion
 

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/fileserver/LokiFileServerProxy.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/fileserver/LokiFileServerProxy.kt
@@ -38,7 +38,7 @@ internal class LokiFileServerProxy(val server: String, private val isFileUpload:
         val deferred = deferred<Response, Exception>()
         Thread {
             val symmetricKey = curve.calculateAgreement(lokiServerPublicKey, keyPair.privateKey)
-            val getProxyPromise = if (isFileUpload) LokiSwarmAPI.getFileServerProxy() else LokiSwarmAPI.getRandomSnode()
+            val getProxyPromise = if (isFileUpload) LokiSwarmAPI.shared.getFileServerProxy() else LokiSwarmAPI.shared.getRandomSnode()
             // Kovenant propagates a context to chained promises, so LokiPublicChatAPI.sharedContext should be used for all of the below
             getProxyPromise.bind(LokiAPI.sharedContext) { proxy ->
                 val url = "${proxy.address}:${proxy.port}/file_proxy"

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -35,8 +35,8 @@ public object OnionRequestAPI {
 
     private val snodePool: Set<Snode>
         get() {
-            val unreliableSnodes = LokiSwarmAPI.failureCount.keys
-            return LokiSwarmAPI.randomSnodePool.minus(unreliableSnodes)
+            val unreliableSnodes = LokiSwarmAPI.shared.failureCount.keys
+            return LokiSwarmAPI.shared.snodePool.minus(unreliableSnodes)
         }
 
     // region Settings
@@ -95,7 +95,7 @@ public object OnionRequestAPI {
             return Promise.of(guardSnodes)
         } else {
             Log.d("Loki", "Populating guard snode cache.")
-            return LokiSwarmAPI.getRandomSnode().bind(LokiAPI.sharedContext) { // Just used to populate the snode pool
+            return LokiSwarmAPI.shared.getRandomSnode().bind(LokiAPI.sharedContext) { // Just used to populate the snode pool
                 var unusedSnodes = snodePool
                 if (unusedSnodes.count() < guardSnodeCount) { throw InsufficientSnodesException() }
                 fun getGuardSnode(): Promise<Snode, Exception> {
@@ -135,7 +135,7 @@ public object OnionRequestAPI {
     public fun buildPaths(): Promise<List<Path>, Exception> {
         Log.d("Loki", "Building onion request paths.")
         LokiAPI.shared.broadcaster.broadcast("buildingPaths")
-        return LokiSwarmAPI.getRandomSnode().bind(LokiAPI.sharedContext) { // Just used to populate the snode pool
+        return LokiSwarmAPI.shared.getRandomSnode().bind(LokiAPI.sharedContext) { // Just used to populate the snode pool
             getGuardSnodes().map(LokiAPI.sharedContext) { guardSnodes ->
                 var unusedSnodes = snodePool.minus(guardSnodes)
                 val pathSnodeCount = guardSnodeCount * pathSize - guardSnodeCount

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -31,7 +31,7 @@ public typealias Snode = LokiAPITarget
  */
 public object OnionRequestAPI {
     public var guardSnodes = setOf<Snode>()
-    public var paths = setOf<Path>()
+    public var paths = listOf<Path>()
 
     private val snodePool: Set<Snode>
         get() {
@@ -40,11 +40,11 @@ public object OnionRequestAPI {
         }
 
     // region Settings
-    private val pathCount = 2 // A main path and a backup path for the case where the target snode is in the main path
     /**
      * The number of snodes (including the guard snode) in a path.
      */
     private val pathSize = 3
+    public val pathCount = 2 // A main path and a backup path for the case where the target snode is in the main path
 
     private val guardSnodeCount
         get() = pathCount // One per path
@@ -132,8 +132,9 @@ public object OnionRequestAPI {
      * Builds and returns `pathCount` paths. The returned promise errors out if not
      * enough (reliable) snodes are available.
      */
-    private fun buildPaths(): Promise<Set<Path>, Exception> {
+    public fun buildPaths(): Promise<List<Path>, Exception> {
         Log.d("Loki", "Building onion request paths.")
+        LokiAPI.shared.broadcaster.broadcast("buildingPaths")
         return LokiSwarmAPI.getRandomSnode().bind(LokiAPI.sharedContext) { // Just used to populate the snode pool
             getGuardSnodes().map(LokiAPI.sharedContext) { guardSnodes ->
                 var unusedSnodes = snodePool.minus(guardSnodes)
@@ -148,7 +149,11 @@ public object OnionRequestAPI {
                     }
                     Log.d("Loki", "Built new onion request path: $result.")
                     result
-                }.toSet()
+                }
+            }.map { paths ->
+                OnionRequestAPI.paths = paths
+                LokiAPI.shared.broadcaster.broadcast("pathsBuilt")
+                paths
             }
         }
     }
@@ -166,14 +171,13 @@ public object OnionRequestAPI {
             return Promise.of(getPath())
         } else {
             return buildPaths().map(LokiAPI.sharedContext) { paths ->
-                OnionRequestAPI.paths = paths
                 getPath()
             }
         }
     }
 
     private fun dropPathContaining(snode: Snode) {
-        paths = paths.filter { !it.contains(snode) }.toSet()
+        paths = paths.filter { !it.contains(snode) }
     }
 
     private fun dropGuardSnode(snode: Snode) {

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -31,7 +31,9 @@ public typealias Snode = LokiAPITarget
  */
 public object OnionRequestAPI {
     public var guardSnodes = setOf<Snode>()
-    public var paths = listOf<Path>()
+    public var paths: List<Path>
+        get() = LokiAPI.shared.database.getPaths()
+        set(newValue) { LokiAPI.shared.database.setPaths(newValue) }
 
     private val snodePool: Set<Snode>
         get() {

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -44,7 +44,7 @@ object OnionRequestAPI {
     /**
      * The number of snodes (including the guard snode) in a path.
      */
-    private val pathSize = 1
+    private val pathSize = 3
 
     private val guardSnodeCount
         get() = pathCount // One per path

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -23,15 +23,15 @@ import javax.crypto.spec.SecretKeySpec
 // region Type Aliases
 private typealias Path = List<LokiAPITarget>
 
-internal typealias Snode = LokiAPITarget
+public typealias Snode = LokiAPITarget
 // endregion
 
 /**
  * See the "Onion Requests" section of [The Session Whitepaper](https://arxiv.org/pdf/2002.04609.pdf) for more information.
  */
-object OnionRequestAPI {
-    private var guardSnodes = setOf<Snode>()
-    private var paths = setOf<Path>()
+public object OnionRequestAPI {
+    public var guardSnodes = setOf<Snode>()
+    public var paths = setOf<Path>()
 
     private val snodePool: Set<Snode>
         get() {

--- a/java/src/main/java/org/whispersystems/signalservice/loki/database/LokiAPIDatabaseProtocol.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/database/LokiAPIDatabaseProtocol.kt
@@ -5,6 +5,8 @@ import org.whispersystems.signalservice.loki.protocol.multidevice.DeviceLink
 
 interface LokiAPIDatabaseProtocol {
 
+    fun getSnodePool(): Set<LokiAPITarget>
+    fun setSnodePool(newValue: Set<LokiAPITarget>)
     fun getSwarmCache(hexEncodedPublicKey: String): Set<LokiAPITarget>?
     fun setSwarmCache(hexEncodedPublicKey: String, newValue: Set<LokiAPITarget>)
     fun getLastMessageHashValue(target: LokiAPITarget): String?

--- a/java/src/main/java/org/whispersystems/signalservice/loki/database/LokiAPIDatabaseProtocol.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/database/LokiAPIDatabaseProtocol.kt
@@ -7,6 +7,8 @@ interface LokiAPIDatabaseProtocol {
 
     fun getSnodePool(): Set<LokiAPITarget>
     fun setSnodePool(newValue: Set<LokiAPITarget>)
+    fun getPaths(): List<List<LokiAPITarget>>
+    fun setPaths(newValue: List<List<LokiAPITarget>>)
     fun getSwarmCache(hexEncodedPublicKey: String): Set<LokiAPITarget>?
     fun setSwarmCache(hexEncodedPublicKey: String, newValue: Set<LokiAPITarget>)
     fun getLastMessageHashValue(target: LokiAPITarget): String?


### PR DESCRIPTION
This PR:

• Implements the onion request UI.
• Sets the number of hops to 3.
• Improves message fetching performance after the app has just started by caching onion request paths and the snode pool.
• Improves security by not requesting the snode pool from the seed nodes on every launch.