### PR TITLE
Further Improved Path Maintenance

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -44,11 +44,11 @@ public object OnionRequestAPI {
     /**
      * The number of times a path can fail before it's replaced.
      */
-    private val pathFailureThreshold = 2
+    private val pathFailureThreshold = 3
     /**
      * The number of times a snode can fail before it's replaced.
      */
-    private val snodeFailureThreshold = 2
+    private val snodeFailureThreshold = 3
     /**
      * The number of paths to maintain.
      */

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -16,10 +16,6 @@ import org.whispersystems.signalservice.loki.api.utilities.EncryptionResult
 import org.whispersystems.signalservice.loki.api.utilities.getBodyForOnionRequest
 import org.whispersystems.signalservice.loki.api.utilities.getHeadersForOnionRequest
 import org.whispersystems.signalservice.loki.utilities.*
-import javax.crypto.Cipher
-import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.SecretKeySpec
-import kotlin.random.Random
 
 private typealias Path = List<Snode>
 
@@ -27,6 +23,7 @@ private typealias Path = List<Snode>
  * See the "Onion Requests" section of [The Session Whitepaper](https://arxiv.org/pdf/2002.04609.pdf) for more information.
  */
 public object OnionRequestAPI {
+    private val pathFailureCount = mutableMapOf<Path, Int>()
     public var guardSnodes = setOf<Snode>()
     public var paths: List<Path> // Not a set to ensure we consistently show the same path to the user
         get() = SnodeAPI.shared.database.getOnionRequestPaths()
@@ -43,10 +40,20 @@ public object OnionRequestAPI {
      * The number of snodes (including the guard snode) in a path.
      */
     private val pathSize = 3
-    public val pathCount = 2 // A main path and a backup path for the case where the target snode is in the main path
+    /**
+     * The number of times a path can fail before it's replaced.
+     */
+    private val pathFailureThreshold = 2
+    /**
+     * The number of paths to maintain.
+     */
+    public val targetPathCount = 2 // A main path and a backup path for the case where the target snode is in the main path
 
-    private val guardSnodeCount
-        get() = pathCount // One per path
+    /**
+     * The number of guard snodes required to maintain `targetPathCount` paths.
+     */
+    private val targetGuardSnodeCount
+        get() = targetPathCount // One per path
     // endregion
 
     class HTTPRequestFailedAtDestinationException(val statusCode: Int, val json: Map<*, *>)
@@ -91,17 +98,18 @@ public object OnionRequestAPI {
     }
 
     /**
-     * Finds `guardSnodeCount` guard snodes to use for path building. The returned promise errors out if not
+     * Finds `targetGuardSnodeCount` guard snodes to use for path building. The returned promise errors out if not
      * enough (reliable) snodes are available.
      */
-    private fun getGuardSnodes(): Promise<Set<Snode>, Exception> {
-        if (guardSnodes.count() >= guardSnodeCount) {
+    private fun getGuardSnodes(reusableGuardSnodes: List<Snode>): Promise<Set<Snode>, Exception> {
+        if (guardSnodes.count() >= targetGuardSnodeCount) {
             return Promise.of(guardSnodes)
         } else {
             Log.d("Loki", "Populating guard snode cache.")
             return SwarmAPI.shared.getRandomSnode().bind(SnodeAPI.sharedContext) { // Just used to populate the snode pool
-                var unusedSnodes = SwarmAPI.shared.snodePool
-                if (unusedSnodes.count() < guardSnodeCount) { throw InsufficientSnodesException() }
+                var unusedSnodes = SwarmAPI.shared.snodePool.minus(reusableGuardSnodes)
+                val reusableGuardSnodeCount = reusableGuardSnodes.count()
+                if (unusedSnodes.count() < (targetGuardSnodeCount - reusableGuardSnodeCount)) { throw InsufficientSnodesException() }
                 fun getGuardSnode(): Promise<Snode, Exception> {
                     val candidate = unusedSnodes.getRandomElementOrNull()
                         ?: return Promise.ofFail(InsufficientSnodesException())
@@ -122,9 +130,9 @@ public object OnionRequestAPI {
                     }
                     return deferred.promise
                 }
-                val promises = (0 until guardSnodeCount).map { getGuardSnode() }
+                val promises = (0 until (targetGuardSnodeCount - reusableGuardSnodeCount)).map { getGuardSnode() }
                 all(promises).map(SnodeAPI.sharedContext) { guardSnodes ->
-                    val guardSnodesAsSet = guardSnodes.toSet()
+                    val guardSnodesAsSet = (guardSnodes + reusableGuardSnodes).toSet()
                     OnionRequestAPI.guardSnodes = guardSnodesAsSet
                     guardSnodesAsSet
                 }
@@ -133,19 +141,21 @@ public object OnionRequestAPI {
     }
 
     /**
-     * Builds and returns `pathCount` paths. The returned promise errors out if not
+     * Builds and returns `targetPathCount` paths. The returned promise errors out if not
      * enough (reliable) snodes are available.
      */
-    private fun buildPaths(): Promise<List<Path>, Exception> {
+    private fun buildPaths(reusablePaths: List<Path>): Promise<List<Path>, Exception> {
         Log.d("Loki", "Building onion request paths.")
         SnodeAPI.shared.broadcaster.broadcast("buildingPaths")
         return SwarmAPI.shared.getRandomSnode().bind(SnodeAPI.sharedContext) { // Just used to populate the snode pool
-            getGuardSnodes().map(SnodeAPI.sharedContext) { guardSnodes ->
-                var unusedSnodes = SwarmAPI.shared.snodePool.minus(guardSnodes)
-                val pathSnodeCount = guardSnodeCount * pathSize - guardSnodeCount
+            val reusableGuardSnodes = reusablePaths.map { it[0] }
+            getGuardSnodes(reusableGuardSnodes).map(SnodeAPI.sharedContext) { guardSnodes ->
+                var unusedSnodes = SwarmAPI.shared.snodePool.minus(guardSnodes).minus(reusablePaths.flatten())
+                val reusableGuardSnodeCount = reusableGuardSnodes.count()
+                val pathSnodeCount = (targetGuardSnodeCount - reusableGuardSnodeCount) * pathSize - (targetGuardSnodeCount - reusableGuardSnodeCount)
                 if (unusedSnodes.count() < pathSnodeCount) { throw InsufficientSnodesException() }
                 // Don't test path snodes as this would reveal the user's IP to them
-                guardSnodes.map { guardSnode ->
+                guardSnodes.minus(reusableGuardSnodes).map { guardSnode ->
                     val result = listOf( guardSnode ) + (0 until (pathSize - 1)).map {
                         val pathSnode = unusedSnodes.getRandomElement()
                         unusedSnodes = unusedSnodes.minus(pathSnode)
@@ -155,7 +165,7 @@ public object OnionRequestAPI {
                     result
                 }
             }.map { paths ->
-                OnionRequestAPI.paths = paths
+                OnionRequestAPI.paths = paths + reusablePaths
                 SnodeAPI.shared.broadcaster.broadcast("pathsBuilt")
                 paths
             }
@@ -168,9 +178,14 @@ public object OnionRequestAPI {
     private fun getPath(snodeToExclude: Snode?): Promise<Path, Exception> {
         if (pathSize < 1) { throw Exception("Can't build path of size zero.") }
         val paths = this.paths
-        if (guardSnodes.isEmpty() && paths.count() >= pathCount) {
-            guardSnodes = setOf( paths[0][0], paths[1][0] )
+        val guardSnodes = mutableSetOf<Snode>()
+        if (paths.isNotEmpty()) {
+            guardSnodes.add(paths[0][0])
+            if (paths.count() >= 2) {
+                guardSnodes.add(paths[1][0])
+            }
         }
+        OnionRequestAPI.guardSnodes = guardSnodes
         fun getPath(paths: List<Path>): Path {
             if (snodeToExclude != null) {
                 return paths.filter { !it.contains(snodeToExclude) }.getRandomElement()
@@ -178,10 +193,19 @@ public object OnionRequestAPI {
                 return paths.getRandomElement()
             }
         }
-        if (paths.count() >= pathCount) {
+        if (paths.count() >= targetPathCount) {
             return Promise.of(getPath(paths))
+        } else if (paths.isNotEmpty()) {
+            if (paths.any { !it.contains(snodeToExclude) }) {
+                buildPaths(paths) // Re-build paths in the background
+                return Promise.of(getPath(paths))
+            } else {
+                return buildPaths(paths).map(SnodeAPI.sharedContext) { newPaths ->
+                    getPath(newPaths)
+                }
+            }
         } else {
-            return buildPaths().map(SnodeAPI.sharedContext) { newPaths ->
+            return buildPaths(listOf()).map(SnodeAPI.sharedContext) { newPaths ->
                 getPath(newPaths)
             }
         }
@@ -192,6 +216,9 @@ public object OnionRequestAPI {
     }
 
     private fun dropSnode(snode: Snode) {
+        // We repair the path here because we can do it sync. In the case where we drop a whole
+        // path we leave the re-building up to getPath() because re-building the path in that case
+        // is async.
         val oldPaths = paths.toMutableList()
         val pathIndex = oldPaths.indexOfFirst { it.contains(snode) }
         if (pathIndex == -1) { return }
@@ -208,8 +235,12 @@ public object OnionRequestAPI {
         paths = newPaths
     }
 
-    private fun dropAllPaths() {
-        paths = listOf()
+    private fun dropPath(path: Path) {
+        val paths = OnionRequestAPI.paths.toMutableList()
+        val pathIndex = paths.indexOf(path)
+        if (pathIndex == -1) { return }
+        paths.removeAt(pathIndex)
+        OnionRequestAPI.paths = paths
     }
 
     /**
@@ -249,52 +280,11 @@ public object OnionRequestAPI {
             }
         }.map(SnodeAPI.sharedContext) { OnionBuildingResult(guardSnode, encryptionResult, destinationSymmetricKey) }
     }
-    // endregion
-
-    // region Internal API
-    /**
-     * Sends an onion request to `snode`. Builds new paths as needed.
-     */
-    internal fun sendOnionRequest(method: Snode.Method, parameters: Map<*, *>, snode: Snode, publicKey: String): Promise<Map<*, *>, Exception> {
-        val payload = mapOf( "method" to method.rawValue, "params" to parameters )
-        return sendOnionRequest(Destination.Snode(snode), payload).recover { exception ->
-            @Suppress("NAME_SHADOWING") val exception = exception as? HTTPRequestFailedAtDestinationException ?: throw exception
-            throw SnodeAPI.shared.handleSnodeError(exception.statusCode, exception.json, snode, publicKey)
-        }
-    }
-
-    /**
-     * Sends an onion request to `server`. Builds new paths as needed.
-     *
-     * `publicKey` is the hex encoded public key of the user the call is associated with. This is needed for swarm cache maintenance.
-     */
-    public fun sendOnionRequest(request: Request, server: String, x25519PublicKey: String, isJSONRequired: Boolean = true): Promise<Map<*, *>, Exception> {
-        val headers = request.getHeadersForOnionRequest()
-        val url = request.url()
-        val urlAsString = url.toString()
-        val host = url.host()
-        val endpoint = when {
-            server.count() < urlAsString.count() -> urlAsString.substringAfter("$server/")
-            else -> ""
-        }
-        val body = request.getBodyForOnionRequest() ?: "null"
-        val payload = mapOf(
-            "body" to body,
-            "endpoint" to endpoint,
-            "method" to request.method(),
-            "headers" to headers
-        )
-        val destination = Destination.Server(host, x25519PublicKey)
-        return sendOnionRequest(destination, payload, isJSONRequired).recover { exception ->
-            Log.d("Loki", "Couldn't reach server: $urlAsString due to error: $exception.")
-            throw exception
-        }
-    }
 
     /**
      * Sends an onion request to `destination`. Builds new paths as needed.
      */
-    internal fun sendOnionRequest(destination: Destination, payload: Map<*, *>, isJSONRequired: Boolean = true): Promise<Map<*, *>, Exception> {
+    private fun sendOnionRequest(destination: Destination, payload: Map<*, *>, isJSONRequired: Boolean = true): Promise<Map<*, *>, Exception> {
         val deferred = deferred<Map<*, *>, Exception>()
         lateinit var guardSnode: Snode
         buildOnionForDestination(payload, destination).success { result ->
@@ -302,8 +292,7 @@ public object OnionRequestAPI {
             val url = "${guardSnode.address}:${guardSnode.port}/onion_req/v2"
             val finalEncryptionResult = result.finalEncryptionResult
             val onion = finalEncryptionResult.ciphertext
-            if (destination is Destination.Server
-                && onion.count().toDouble() > 0.75 * FileServerAPI.maxFileSize.toDouble()) {
+            if (destination is Destination.Server && onion.count().toDouble() > 0.75 * FileServerAPI.maxFileSize.toDouble()) {
                 Log.d("Loki", "Approaching request size limit: ~${onion.count()} bytes.")
             }
             @Suppress("NAME_SHADOWING") val parameters = mapOf(
@@ -372,12 +361,19 @@ public object OnionRequestAPI {
             val path = paths.firstOrNull { it.contains(guardSnode) }
             if (exception is HTTP.HTTPRequestFailedException) {
                 fun handleUnspecificError() {
-                    path?.forEach { snode ->
-                        @Suppress("ThrowableNotThrown")
-                        SnodeAPI.shared.handleSnodeError(exception.statusCode, exception.json, snode, null) // Intentionally don't throw
+                    if (path == null) { return }
+                    var pathFailureCount = OnionRequestAPI.pathFailureCount.get(path) ?: 0
+                    pathFailureCount += 1
+                    if (pathFailureCount >= pathFailureThreshold) {
+                        dropGuardSnode(guardSnode)
+                        path.forEach { snode ->
+                            @Suppress("ThrowableNotThrown")
+                            SnodeAPI.shared.handleSnodeError(exception.statusCode, exception.json, snode, null) // Intentionally don't throw
+                        }
+                        dropPath(path)
+                    } else {
+                        OnionRequestAPI.pathFailureCount[path] = pathFailureCount
                     }
-                    dropAllPaths()
-                    dropGuardSnode(guardSnode)
                 }
                 val json = exception.json
                 val message = json?.get("result") as? String
@@ -402,6 +398,47 @@ public object OnionRequestAPI {
             }
         }
         return promise
+    }
+    // endregion
+
+    // region Internal API
+    /**
+     * Sends an onion request to `snode`. Builds new paths as needed.
+     */
+    internal fun sendOnionRequest(method: Snode.Method, parameters: Map<*, *>, snode: Snode, publicKey: String): Promise<Map<*, *>, Exception> {
+        val payload = mapOf( "method" to method.rawValue, "params" to parameters )
+        return sendOnionRequest(Destination.Snode(snode), payload).recover { exception ->
+            @Suppress("NAME_SHADOWING") val exception = exception as? HTTPRequestFailedAtDestinationException ?: throw exception
+            throw SnodeAPI.shared.handleSnodeError(exception.statusCode, exception.json, snode, publicKey)
+        }
+    }
+
+    /**
+     * Sends an onion request to `server`. Builds new paths as needed.
+     *
+     * `publicKey` is the hex encoded public key of the user the call is associated with. This is needed for swarm cache maintenance.
+     */
+    public fun sendOnionRequest(request: Request, server: String, x25519PublicKey: String, isJSONRequired: Boolean = true): Promise<Map<*, *>, Exception> {
+        val headers = request.getHeadersForOnionRequest()
+        val url = request.url()
+        val urlAsString = url.toString()
+        val host = url.host()
+        val endpoint = when {
+            server.count() < urlAsString.count() -> urlAsString.substringAfter("$server/")
+            else -> ""
+        }
+        val body = request.getBodyForOnionRequest() ?: "null"
+        val payload = mapOf(
+            "body" to body,
+            "endpoint" to endpoint,
+            "method" to request.method(),
+            "headers" to headers
+        )
+        val destination = Destination.Server(host, x25519PublicKey)
+        return sendOnionRequest(destination, payload, isJSONRequired).recover { exception ->
+            Log.d("Loki", "Couldn't reach server: $urlAsString due to error: $exception.")
+            throw exception
+        }
     }
     // endregion
 }

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestEncryption.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestEncryption.kt
@@ -6,6 +6,7 @@ import org.whispersystems.signalservice.internal.util.JsonUtil
 import org.whispersystems.signalservice.loki.api.utilities.EncryptionResult
 import org.whispersystems.signalservice.loki.api.utilities.EncryptionUtilities
 import org.whispersystems.signalservice.loki.utilities.toHexString
+import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -19,7 +20,9 @@ object OnionRequestEncryption {
         buffer.order(ByteOrder.LITTLE_ENDIAN)
         buffer.putInt(ciphertextSize)
         val ciphertextSizeAsData = ByteArray(buffer.capacity())
-        buffer.position(0)
+        // Casting here avoids an issue where this gets compiled down to incorrect byte code. See
+        // https://github.com/eclipse/jetty.project/issues/3244 for more info
+        (buffer as Buffer).position(0)
         buffer.get(ciphertextSizeAsData)
         return ciphertextSizeAsData + ciphertext + jsonAsData
     }

--- a/java/src/main/java/org/whispersystems/signalservice/loki/utilities/DownloadUtilities.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/utilities/DownloadUtilities.kt
@@ -53,6 +53,7 @@ object DownloadUtilities {
             val data = json["data"] as? ArrayList<Int>
             if (data == null) {
                 Log.d("Loki", "Couldn't parse attachment from: $json.")
+                Log.d("Test", "Failing URL: $sanitizedURL")
                 throw PushNetworkException("Missing response body.")
             }
             val body = data.map { it.toByte() }.toByteArray()

--- a/java/src/main/java/org/whispersystems/signalservice/loki/utilities/DownloadUtilities.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/utilities/DownloadUtilities.kt
@@ -53,7 +53,6 @@ object DownloadUtilities {
             val data = json["data"] as? ArrayList<Int>
             if (data == null) {
                 Log.d("Loki", "Couldn't parse attachment from: $json.")
-                Log.d("Test", "Failing URL: $sanitizedURL")
                 throw PushNetworkException("Missing response body.")
             }
             val body = data.map { it.toByte() }.toByteArray()

--- a/java/src/main/java/org/whispersystems/signalservice/loki/utilities/DownloadUtilities.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/utilities/DownloadUtilities.kt
@@ -43,7 +43,9 @@ object DownloadUtilities {
         if (oldPrefixedHost.contains(FileServerAPI.fileStorageBucketURL)) {
             newPrefixedHost = FileServerAPI.shared.server
         }
-        val fileID = url.substringAfter("$oldPrefixedHost/f/")
+        // Edge case that needs to work: https://file-static.lokinet.org/i1pNmpInq3w9gF3TP8TFCa1rSo38J6UM
+        // → https://file.getsession.org/loki/v1/f/XLxogNXVEIWHk14NVCDeppzTujPHxu35
+        val fileID = url.substringAfter(oldPrefixedHost).substringAfter("/f/")
         val sanitizedURL = "$newPrefixedHost/loki/v1/f/$fileID"
         val request = Request.Builder().url(sanitizedURL).get()
         try {


### PR DESCRIPTION
Branched from #90 

### What's in this PR:

• If a path fails we now only drop that path, instead of \* all \* paths.
• Path re-building now no longer blocks, meaning that if there's still a usable path we now use that path and re-build the other path in the background.
• We now don't immediately drop a path if it fails, but let it fail once first (often a path that failed will actually work fine upon retrying).