### PR TITLE
Refactor new Thread creation into shared thread pool executor

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiMessage.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/LokiMessage.kt
@@ -6,6 +6,7 @@ import org.whispersystems.libsignal.logging.Log
 import org.whispersystems.signalservice.internal.util.Base64
 import org.whispersystems.signalservice.loki.api.crypto.ProofOfWork
 import org.whispersystems.signalservice.loki.protocol.meta.TTLUtilities
+import org.whispersystems.signalservice.loki.utilities.ThreadUtils
 import org.whispersystems.signalservice.loki.utilities.prettifiedDescription
 
 internal data class LokiMessage(
@@ -60,7 +61,7 @@ internal data class LokiMessage(
     internal fun calculatePoW(): Promise<LokiMessage, Exception> {
         val deferred = deferred<LokiMessage, Exception>()
         // Run PoW in a background thread
-        Thread {
+        ThreadUtils.queue {
             val now = System.currentTimeMillis()
             val nonce = ProofOfWork.calculate(data, recipientPublicKey, now, ttl)
             if (nonce != null ) {
@@ -68,7 +69,7 @@ internal data class LokiMessage(
             } else {
                 deferred.reject(SnodeAPI.Error.ProofOfWorkCalculationFailed)
             }
-        }.start()
+        }
         return deferred.promise
     }
 

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/SnodeAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/SnodeAPI.kt
@@ -13,6 +13,7 @@ import org.whispersystems.signalservice.loki.api.onionrequests.OnionRequestAPI
 import org.whispersystems.signalservice.loki.api.utilities.HTTP
 import org.whispersystems.signalservice.loki.database.LokiAPIDatabaseProtocol
 import org.whispersystems.signalservice.loki.utilities.Broadcaster
+import org.whispersystems.signalservice.loki.utilities.ThreadUtils
 import org.whispersystems.signalservice.loki.utilities.createContext
 import org.whispersystems.signalservice.loki.utilities.prettifiedDescription
 import org.whispersystems.signalservice.loki.utilities.retryIfNeeded
@@ -22,12 +23,12 @@ import java.net.SocketTimeoutException
 class SnodeAPI private constructor(public var userPublicKey: String, public val database: LokiAPIDatabaseProtocol, public val broadcaster: Broadcaster) {
 
     companion object {
-        val messageSendingContext = Kovenant.createContext("LokiAPIMessageSendingContext")
-        val messagePollingContext = Kovenant.createContext("LokiAPIMessagePollingContext")
+        val messageSendingContext = Kovenant.createContext()
+        val messagePollingContext = Kovenant.createContext()
         /**
          * For operations that are shared between message sending and message polling.
          */
-        val sharedContext = Kovenant.createContext("LokiAPISharedContext")
+        val sharedContext = Kovenant.createContext()
 
         // region Initialization
         lateinit var shared: SnodeAPI
@@ -75,7 +76,7 @@ class SnodeAPI private constructor(public var userPublicKey: String, public val 
             return OnionRequestAPI.sendOnionRequest(method, parameters, snode, publicKey)
         } else {
             val deferred = deferred<Map<*, *>, Exception>()
-            Thread {
+            ThreadUtils.queue {
                 val payload = mapOf( "method" to method.rawValue, "params" to parameters )
                 try {
                     val json = HTTP.execute(HTTP.Verb.POST, url, payload)
@@ -87,13 +88,13 @@ class SnodeAPI private constructor(public var userPublicKey: String, public val 
                         val httpRequestFailedException = exception as? HTTP.HTTPRequestFailedException
                         if (httpRequestFailedException != null) {
                             @Suppress("NAME_SHADOWING") val exception = handleSnodeError(httpRequestFailedException.statusCode, httpRequestFailedException.json, snode, publicKey)
-                            return@Thread deferred.reject(exception)
+                            return@queue deferred.reject(exception)
                         }
                         Log.d("Loki", "Unhandled exception: $exception.")
                     }
                     deferred.reject(exception)
                 }
-            }.start()
+            }
             return deferred.promise
         }
     }

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/SwarmAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/SwarmAPI.kt
@@ -8,6 +8,7 @@ import nl.komponents.kovenant.task
 import org.whispersystems.libsignal.logging.Log
 import org.whispersystems.signalservice.loki.api.utilities.HTTP
 import org.whispersystems.signalservice.loki.database.LokiAPIDatabaseProtocol
+import org.whispersystems.signalservice.loki.utilities.ThreadUtils
 import org.whispersystems.signalservice.loki.utilities.getRandomElement
 import org.whispersystems.signalservice.loki.utilities.prettifiedDescription
 import org.whispersystems.signalservice.loki.utilities.retryIfNeeded
@@ -67,7 +68,7 @@ class SwarmAPI private constructor(private val database: LokiAPIDatabaseProtocol
             )
             val deferred = deferred<Snode, Exception>()
             deferred<Snode, Exception>(SnodeAPI.sharedContext)
-            Thread {
+            ThreadUtils.queue {
                 try {
                     val json = HTTP.execute(HTTP.Verb.POST, url, parameters, useSeedNodeConnection = true)
                     val intermediate = json["result"] as? Map<*, *>
@@ -101,7 +102,7 @@ class SwarmAPI private constructor(private val database: LokiAPIDatabaseProtocol
                 } catch (exception: Exception) {
                     deferred.reject(exception)
                 }
-            }.start()
+            }
             return deferred.promise
         } else {
             return Promise.of(snodePool.getRandomElement())

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestAPI.kt
@@ -82,12 +82,12 @@ object OnionRequestAPI {
      */
     private fun testSnode(snode: Snode): Promise<Unit, Exception> {
         val deferred = deferred<Unit, Exception>()
-        Thread { // No need to block the shared context for this
+        ThreadUtils.queue { // No need to block the shared context for this
             val url = "${snode.address}:${snode.port}/get_stats/v1"
             try {
                 val json = HTTP.execute(HTTP.Verb.GET, url)
                 val version = json["version"] as? String
-                if (version == null) { deferred.reject(Exception("Missing snode version.")); return@Thread }
+                if (version == null) { deferred.reject(Exception("Missing snode version.")); return@queue }
                 if (version >= "2.0.7") {
                     deferred.resolve(Unit)
                 } else {
@@ -98,7 +98,7 @@ object OnionRequestAPI {
             } catch (exception: Exception) {
                 deferred.reject(exception)
             }
-        }.start()
+        }
         return deferred.promise
     }
 
@@ -312,10 +312,10 @@ object OnionRequestAPI {
                 return@success deferred.reject(exception)
             }
             val destinationSymmetricKey = result.destinationSymmetricKey
-            Thread {
+            ThreadUtils.queue {
                 try {
                     val json = HTTP.execute(HTTP.Verb.POST, url, body)
-                    val base64EncodedIVAndCiphertext = json["result"] as? String ?: return@Thread deferred.reject(Exception("Invalid JSON"))
+                    val base64EncodedIVAndCiphertext = json["result"] as? String ?: return@queue deferred.reject(Exception("Invalid JSON"))
                     val ivAndCiphertext = Base64.decode(base64EncodedIVAndCiphertext)
                     try {
                         val plaintext = DecryptionUtilities.decryptUsingAESGCM(ivAndCiphertext, destinationSymmetricKey)
@@ -325,7 +325,7 @@ object OnionRequestAPI {
                             if (statusCode == 406) {
                                 @Suppress("NAME_SHADOWING") val body = mapOf( "result" to "Your clock is out of sync with the service node network." )
                                 val exception = HTTPRequestFailedAtDestinationException(statusCode, body)
-                                return@Thread deferred.reject(exception)
+                                return@queue deferred.reject(exception)
                             } else if (json["body"] != null) {
                                 @Suppress("NAME_SHADOWING") val body: Map<*, *>
                                 if (json["body"] is Map<*, *>) {
@@ -340,13 +340,13 @@ object OnionRequestAPI {
                                 }
                                 if (statusCode != 200) {
                                     val exception = HTTPRequestFailedAtDestinationException(statusCode, body)
-                                    return@Thread deferred.reject(exception)
+                                    return@queue deferred.reject(exception)
                                 }
                                 deferred.resolve(body)
                             } else {
                                 if (statusCode != 200) {
                                     val exception = HTTPRequestFailedAtDestinationException(statusCode, json)
-                                    return@Thread deferred.reject(exception)
+                                    return@queue deferred.reject(exception)
                                 }
                                 deferred.resolve(json)
                             }
@@ -359,7 +359,7 @@ object OnionRequestAPI {
                 } catch (exception: Exception) {
                     deferred.reject(exception)
                 }
-            }.start()
+            }
         }.fail { exception ->
             deferred.reject(exception)
         }

--- a/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestEncryption.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/api/onionrequests/OnionRequestEncryption.kt
@@ -5,6 +5,7 @@ import nl.komponents.kovenant.deferred
 import org.whispersystems.signalservice.internal.util.JsonUtil
 import org.whispersystems.signalservice.loki.api.utilities.EncryptionResult
 import org.whispersystems.signalservice.loki.api.utilities.EncryptionUtilities
+import org.whispersystems.signalservice.loki.utilities.ThreadUtils
 import org.whispersystems.signalservice.loki.utilities.toHexString
 import java.nio.Buffer
 import java.nio.ByteBuffer
@@ -32,7 +33,7 @@ object OnionRequestEncryption {
      */
     internal fun encryptPayloadForDestination(payload: Map<*, *>, destination: OnionRequestAPI.Destination): Promise<EncryptionResult, Exception> {
         val deferred = deferred<EncryptionResult, Exception>()
-        Thread {
+        ThreadUtils.queue {
             try {
                 // Wrapping isn't needed for file server or open group onion requests
                 when (destination) {
@@ -52,7 +53,7 @@ object OnionRequestEncryption {
             } catch (exception: Exception) {
                 deferred.reject(exception)
             }
-        }.start()
+        }
         return deferred.promise
     }
 
@@ -61,7 +62,7 @@ object OnionRequestEncryption {
      */
     internal fun encryptHop(lhs: OnionRequestAPI.Destination, rhs: OnionRequestAPI.Destination, previousEncryptionResult: EncryptionResult): Promise<EncryptionResult, Exception> {
         val deferred = deferred<EncryptionResult, Exception>()
-        Thread {
+        ThreadUtils.queue {
             try {
                 val payload: MutableMap<String, Any>
                 when (rhs) {
@@ -88,7 +89,7 @@ object OnionRequestEncryption {
             } catch (exception: Exception) {
                 deferred.reject(exception)
             }
-        }.start()
+        }
         return deferred.promise
     }
 }

--- a/java/src/main/java/org/whispersystems/signalservice/loki/utilities/PromiseUtilities.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/utilities/PromiseUtilities.kt
@@ -4,10 +4,11 @@ package org.whispersystems.signalservice.loki.utilities
 import nl.komponents.kovenant.*
 import nl.komponents.kovenant.jvm.asDispatcher
 import org.whispersystems.libsignal.logging.Log
+import java.util.concurrent.Executors
 
 fun Kovenant.createContext(): Context {
     return createContext {
-        callbackContext.dispatcher = ThreadUtils.executorPool.asDispatcher()
+        callbackContext.dispatcher = Executors.newSingleThreadExecutor().asDispatcher()
         workerContext.dispatcher = ThreadUtils.executorPool.asDispatcher()
         multipleCompletion = { v1, v2 ->
             Log.d("Loki", "Promise resolved more than once (first with $v1, then with $v2); ignoring $v2.")

--- a/java/src/main/java/org/whispersystems/signalservice/loki/utilities/PromiseUtilities.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/utilities/PromiseUtilities.kt
@@ -2,25 +2,13 @@
 package org.whispersystems.signalservice.loki.utilities
 
 import nl.komponents.kovenant.*
+import nl.komponents.kovenant.jvm.asDispatcher
 import org.whispersystems.libsignal.logging.Log
-import kotlin.math.max
 
-// Try to use all available threads minus one for the callback
-private val recommendedThreadCount: Int
-    get() = Runtime.getRuntime().availableProcessors() - 1
-
-fun Kovenant.createContext(contextName: String, threadCount: Int = max(recommendedThreadCount, 1)): Context {
+fun Kovenant.createContext(): Context {
     return createContext {
-        callbackContext.dispatcher = buildDispatcher {
-            name = "${contextName}CallbackDispatcher"
-            // Ref: http://kovenant.komponents.nl/api/core_usage/#execution-order
-            // Having 1 concurrent task ensures we have in-order callback handling
-            concurrentTasks = 1
-        }
-        workerContext.dispatcher = buildDispatcher {
-            name = "${contextName}WorkerDispatcher"
-            concurrentTasks = threadCount
-        }
+        callbackContext.dispatcher = ThreadUtils.executorPool.asDispatcher()
+        workerContext.dispatcher = ThreadUtils.executorPool.asDispatcher()
         multipleCompletion = { v1, v2 ->
             Log.d("Loki", "Promise resolved more than once (first with $v1, then with $v2); ignoring $v2.")
         }

--- a/java/src/main/java/org/whispersystems/signalservice/loki/utilities/ThreadUtils.kt
+++ b/java/src/main/java/org/whispersystems/signalservice/loki/utilities/ThreadUtils.kt
@@ -1,0 +1,18 @@
+package org.whispersystems.signalservice.loki.utilities
+
+import java.util.concurrent.Executors
+
+object ThreadUtils {
+
+    internal val executorPool = Executors.newCachedThreadPool()
+
+    @JvmStatic
+    fun queue(target: Runnable) {
+        executorPool.execute(target)
+    }
+
+    fun queue(target: ()->Unit) {
+        executorPool.execute(target)
+    }
+
+}


### PR DESCRIPTION
This affects the kovenant shared executors and the manual calls in the various APIs as well as exposing JVM/Kotlin methods to the consumer